### PR TITLE
Provide clearer error message upon failed user creation.

### DIFF
--- a/ngo-ui/src/app/ui/signup/signup.component.ts
+++ b/ngo-ui/src/app/ui/signup/signup.component.ts
@@ -72,7 +72,7 @@ export class SignupComponent implements OnInit {
             },
             err => {
               this.loading = false;
-              this.error = 'Username or email already in use!';
+              this.error = err.statusText;
             }
           );
         } else {
@@ -82,7 +82,7 @@ export class SignupComponent implements OnInit {
       },
       err => {
         this.loading = false;
-        this.error = 'Username or email already in use!';
+        this.error = err.statusText + ". Ensure you are using HTTP, not HTTPS, to access the site.";
       }
     );
   }


### PR DESCRIPTION
*Issue #, if available:*
Related to https://github.com/aws-samples/non-profit-blockchain/issues/17

This has been reported by a few users.  The preview url launched by Cloud9 is an HTTPS url, but because the ELB only runs on HTTP, it is failing the request to sign up a new user.

*Description of changes:*

This PR does *not* resolve the http/s issue, but it does guide the user to fixing it themselves.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
