### PR TITLE
Gen conn profile remove org2

### DIFF
--- a/ngo-rest-api/connection-profile/gen-connection-profile.sh
+++ b/ngo-rest-api/connection-profile/gen-connection-profile.sh
@@ -20,7 +20,6 @@ LOCALCA=/home/ec2-user/managedblockchain-tls-chain.pem
 
 #copy the connection profiles
 mkdir -p $REPODIR/tmp/connection-profile/org1
-mkdir -p $REPODIR/tmp/connection-profile/org2
 cp $REPODIR/ngo-rest-api/connection-profile/ngo-connection-profile-template.yaml $REPODIR/tmp/connection-profile/ngo-connection-profile.yaml
 cp $REPODIR/ngo-rest-api/connection-profile/client-org1.yaml $REPODIR/tmp/connection-profile/org1
 

--- a/ngo-rest-api/connection-profile/gen-connection-profile.sh
+++ b/ngo-rest-api/connection-profile/gen-connection-profile.sh
@@ -23,7 +23,6 @@ mkdir -p $REPODIR/tmp/connection-profile/org1
 mkdir -p $REPODIR/tmp/connection-profile/org2
 cp $REPODIR/ngo-rest-api/connection-profile/ngo-connection-profile-template.yaml $REPODIR/tmp/connection-profile/ngo-connection-profile.yaml
 cp $REPODIR/ngo-rest-api/connection-profile/client-org1.yaml $REPODIR/tmp/connection-profile/org1
-cp $REPODIR/ngo-rest-api/connection-profile/client-org2.yaml $REPODIR/tmp/connection-profile/org2
 
 #update the connection profiles with endpoints and other information
 sed -i "s|%PEERNODEID%|$PEERNODEID|g" $REPODIR/tmp/connection-profile/ngo-connection-profile.yaml


### PR DESCRIPTION
*Issue #, if available:*
This wasn't breaking anything but it was outputting an error because there is `client-org2.yaml` file.

*Description of changes:*
Remove the references to `org2`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
