### PR TITLE
Update README to address a common issue encountered during the workshop

### DIFF
--- a/ngo-rest-api/README.md
+++ b/ngo-rest-api/README.md
@@ -83,8 +83,8 @@ more ~/non-profit-blockchain/tmp/connection-profile/ngo-connection-profile.yaml
 ```
 
 Check the config file used by app.js. Make sure the peer name in config.json (under 'peers:') is 
-the same as the peer name in the connection profile. Also check that the admin username and 
-password are correct and match the values you updated in the connection profile.
+the same as the peer name in the connection profile. **Make sure the admin username and 
+password are correct and match the values you updated in the connection profile.**
 
 ```
 cd ~/non-profit-blockchain/ngo-rest-api
@@ -105,8 +105,8 @@ config.json should look something like this:
     ],
     "admins":[
        {
-          "username":"admin",
-          "secret":"Adminpwd1!"
+          "username":"admin", <-- update for your env
+          "secret":"Adminpwd1!" <-- update for your env
        }
     ]
  }
@@ -115,15 +115,19 @@ config.json should look something like this:
 ## Step 4 - Run the REST API Node.js application
 On the Fabric client node.
 
-Run the app (in the background if you prefer):
+Run the app:
 
 ```
 cd ~/non-profit-blockchain/ngo-rest-api
 nvm use lts/carbon
-node app.js &
+node app.js 
 ```
 
 ## Step 5 - Test the REST API
+Open a new terminal pane within Cloud 9.  Click on Window -> New Terminal.
+
+From the new terminal, SSH into the Fabric cilent node.  Run the same SSH command you used earlier.
+
 On the Fabric client node.
 
 Once the app is running you can register an identity, and then start to execute chaincode. The command
@@ -141,6 +145,8 @@ response:
 ```
 {"success":true,"secret":"","message":"michael enrolled Successfully"}
 ```
+
+**If you encounter an error such as `{"code":20,"message":"Authorization failure"}`, it is likely because the admin credentials in `config.json` above are incorrect.  Update those and restart the REST API server that is running in the other terminal.**
 
 ### POST a Donor
 


### PR DESCRIPTION
*Description of changes:*
Several (around 10) workshop participants ran into the same issue whereby they were not able to register a user via the API.  This was because they had not set their admin creds in `config.json`.

I updated the README to boldly call out that they need to do this, as well as what to do in the event they see the error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
