### PR TITLE
Update UI Readme to address a common issue during the workshop

### DIFF
--- a/ngo-ui/README.md
+++ b/ngo-ui/README.md
@@ -24,6 +24,8 @@ simulating two users sharing the same IDE session.
 ## Pre-requisites
 On Cloud9.
 
+Open a new terminal pane.  Click on Window -> New Terminal.  **You should not be SSH'ed into the Fabric Client for this.**
+
 Your REST API should be exposed via an AWS Elastic Load Balancer (ELB). The ELB was created for you
 by AWS CloudFormation in [Part 1](../ngo-fabric/README.md). You can find the DNS endpoint for the ELB in
 the Outputs of your CloudFormation stack in the AWS CloudFormation console.
@@ -96,7 +98,9 @@ icon next to the URL in the preview pane.
 
 NOTE: You must remove the `https://` protocol from the Cloud9 URL. The application does not use TLS/SSL,
 and most modern browsers will not allow you to call an HTTPS endpoint when the underlying application
-makes HTTP calls. 
+makes HTTP calls.
+
+**If the application is not loading, check that you started the Angular app in a Cloud 9 terminal, and not on the Fabric Client Node.**
 
 ## Step 5 - Register a user in the application
 Registering a user is necessary before you carry out any tasks in the UI application. User registration


### PR DESCRIPTION
*Description of changes:*
A few of the workshop attendees ran into an issue where they were unable to view their UI in the browser.  It worked via curl.  The issue was that they had launched the Angular app in the EC2 instance, instead of the Cloud9 instance.

I updated the README to try to help them clearly understand where they should be running these commands.

I think the confusion happened because they were running through the entire workshop at once, whereas if you were to just pickup again from Step 4, there is nothing on that page about SSH'ing into the EC2 instance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
