### PR TITLE
Remove all usage of vi from the workshop

### DIFF
--- a/ngo-fabric/README.md
+++ b/ngo-fabric/README.md
@@ -70,8 +70,9 @@ In Cloud9:
 
 ```
 export REGION=us-east-1
-export NETWORKID=<the network ID you created in Step1, from the Amazon Managed Blockchain Console>
-export NETWORKNAME=<the name you gave the network>
+export FABRICSTACK=ngo-fabric-network
+export NETWORKID=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='NetworkID'].OutputValue" --output text)
+export NETWORKNAME=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='NETWORKNAME'].OutputValue" --output text)
 ```
 
 Set the VPC endpoint. Make sure it has been populated and exported. If the `echo` statement below shows
@@ -124,10 +125,14 @@ git clone https://github.com/aws-samples/non-profit-blockchain.git
 Set environment variables to reference your Managed Blockchain network.  The info you need either matches what you entered when creating the Fabric network in [Part 1](../ngo-fabric/README.md), or can be found in the Amazon Managed Blockchain Console, under your network.
 
 ```
-export MEMBERID=<your member ID, from the Amazon Managed Blockchain Console>
-export MEMBERNAME=<the member name you chose when creating your Fabric network>
-export ADMINUSER=<the admin user name you chose when creating your Fabric network>
-export ADMINPWD=<the admin password you chose when creating your Fabric network>
+export REGION=us-east-1
+export FABRICSTACK=ngo-fabric-network
+export NETWORKID=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='NetworkID'].OutputValue" --output text)
+export NETWORKNAME=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='NETWORKNAME'].OutputValue" --output text)
+export MEMBERID=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='MemberID'].OutputValue" --output text)
+export MEMBERNAME=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='MemberName'].OutputValue" --output text)
+export ADMINUSER=admin
+export ADMINPWD=AdminPwd!
 ```
 
 Create the file that includes the ENV export values that define your Fabric network configuration.

--- a/ngo-fabric/README.md
+++ b/ngo-fabric/README.md
@@ -97,7 +97,7 @@ You will find some useful information in the Outputs tab of the CloudFormation s
 is complete. We will use this information in later steps.
 
 ## Step 4 - Prepare the Fabric client node and enroll an identity
-On the Fabric client node.
+In your Cloud9 terminal window.
 
 Prior to executing any commands on the Fabric client node, you will need to export ENV variables
 that provide a context to Hyperledger Fabric. These variables will tell the client node which peer
@@ -126,7 +126,12 @@ Create the file that includes the ENV export values that define your Fabric netw
 ```
 cd ~/non-profit-blockchain/ngo-fabric
 cp templates/exports-template.sh fabric-exports.sh
-vi fabric-exports.sh
+sed -i "s|__NETWORKNAME__|<your network name>|g" fabric-exports.sh 
+sed -i "s|__MEMBERNAME__|<the member name you entered when creating your Fabric network>|g" fabric-exports.sh 
+sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" fabric-exports.sh 
+sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" fabric-exports.sh 
+sed -i "s|__NETWORKID__|<your network ID, from the AWS Console>|g" fabric-exports.sh 
+sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" fabric-exports.sh 
 ```
 
 Update the export statements at the top of the file. The info you need either matches what you 
@@ -205,7 +210,7 @@ directory below, NOT the one in the repo:
 
 ```
 cp ~/non-profit-blockchain/ngo-fabric/configtx.yaml ~
-vi ~/configtx.yaml
+sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" ~/configtx.yaml
 ```
 
 Generate the configtx channel configuration by executing the following script. When the channel is created, this channel configuration will become the genesis block (i.e. block 0) on the channel:

--- a/ngo-fabric/README.md
+++ b/ngo-fabric/README.md
@@ -121,6 +121,15 @@ cd ~
 git clone https://github.com/aws-samples/non-profit-blockchain.git
 ```
 
+Set environment variables to reference your Managed Blockchain network.  The info you need either matches what you entered when creating the Fabric network in [Part 1](../ngo-fabric/README.md), or can be found in the Amazon Managed Blockchain Console, under your network.
+
+```
+export MEMBERID=<your member ID, from the Amazon Managed Blockchain Console>
+export MEMBERNAME=<the member name you chose when creating your Fabric network>
+export ADMINUSER=<the admin user name you chose when creating your Fabric network>
+export ADMINPWD=<the admin password you chose when creating your Fabric network>
+```
+
 Create the file that includes the ENV export values that define your Fabric network configuration.
 
 ```
@@ -128,18 +137,13 @@ cd ~/non-profit-blockchain/ngo-fabric
 cp templates/exports-template.sh fabric-exports.sh
 sed -i "s|__NETWORKNAME__|$NETWORKNAME|g" fabric-exports.sh
 sed -i "s|__NETWORKID__|$NETWORKID|g" fabric-exports.sh
-sed -i "s|__MEMBERNAME__|<the member name you entered when creating your Fabric network>|g" fabric-exports.sh
-sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" fabric-exports.sh
-sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" fabric-exports.sh
-sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" fabric-exports.sh
+sed -i "s|__MEMBERNAME__|$MEMBERNAME|g" fabric-exports.sh
+sed -i "s|__MEMBERID__|$MEMBERID|g" fabric-exports.sh
+sed -i "s|__ADMINUSER__|$ADMINUSER|g" fabric-exports.sh
+sed -i "s|__ADMINPWD__|$ADMINPWD|g" fabric-exports.sh
 ```
 
-Update the export statements at the top of the file. The info you need either matches what you 
-entered when creating the Fabric network in [Part 1](../ngo-fabric/README.md), or can be found 
-in the Amazon Managed Blockchain Console, under your network.
-
-Source the file, so the exports are applied to your current session. If you exit the SSH 
-session and re-connect, you'll need to source the file again.
+Source the file, so the exports are applied to your current session. If you exit the SSH session and re-connect, you'll need to source the file again.
 
 ```
 cd ~/non-profit-blockchain/ngo-fabric
@@ -198,8 +202,7 @@ cd ~/non-profit-blockchain/ngo-fabric
 On the Fabric client node.
 
 Update the configtx channel configuration. The Name and ID fields should be updated with the member ID. 
-You can obtain the member ID from the Amazon Managed Blockchain Console, or from the ENV variables 
-exported to your current session.
+You can obtain the member ID from the Amazon Managed Blockchain Console, or from the ENV variables exported to your current session.
 
 ```
 echo $MEMBERID

--- a/ngo-fabric/README.md
+++ b/ngo-fabric/README.md
@@ -126,12 +126,12 @@ Create the file that includes the ENV export values that define your Fabric netw
 ```
 cd ~/non-profit-blockchain/ngo-fabric
 cp templates/exports-template.sh fabric-exports.sh
-sed -i "s|__NETWORKNAME__|<your network name>|g" fabric-exports.sh 
-sed -i "s|__MEMBERNAME__|<the member name you entered when creating your Fabric network>|g" fabric-exports.sh 
-sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" fabric-exports.sh 
-sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" fabric-exports.sh 
-sed -i "s|__NETWORKID__|<your network ID, from the AWS Console>|g" fabric-exports.sh 
-sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" fabric-exports.sh 
+sed -i "s|__NETWORKNAME__|$NETWORKNAME|g" fabric-exports.sh
+sed -i "s|__NETWORKID__|$NETWORKID|g" fabric-exports.sh
+sed -i "s|__MEMBERNAME__|<the member name you entered when creating your Fabric network>|g" fabric-exports.sh
+sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" fabric-exports.sh
+sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" fabric-exports.sh
+sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" fabric-exports.sh
 ```
 
 Update the export statements at the top of the file. The info you need either matches what you 
@@ -210,7 +210,7 @@ directory below, NOT the one in the repo:
 
 ```
 cp ~/non-profit-blockchain/ngo-fabric/configtx.yaml ~
-sed -i "s|__MEMBERID__|<your member ID, from the AWS Console>|g" ~/configtx.yaml
+sed -i "s|__MEMBERID__|$MEMBERID|g" ~/configtx.yaml
 ```
 
 Generate the configtx channel configuration by executing the following script. When the channel is created, this channel configuration will become the genesis block (i.e. block 0) on the channel:

--- a/ngo-fabric/configtx.yaml
+++ b/ngo-fabric/configtx.yaml
@@ -21,10 +21,10 @@
 ################################################################################
 Organizations:
     - &Org1
-        Name: <REPLACE WITH MEMBER_ID> 
+        Name: __MEMBERID__ 
 
         # ID to load the MSP definition as
-        ID: <REPLACE WITH MEMBER_ID>
+        ID: __MEMBERID__
 
         MSPDir: /opt/home/admin-msp
 

--- a/ngo-fabric/templates/exports-template.sh
+++ b/ngo-fabric/templates/exports-template.sh
@@ -15,13 +15,13 @@
 
 # Update these values, then `source` this script
 export REGION=us-east-1
-export NETWORKNAME=<your network name>
-export MEMBERNAME=<the member name you entered when creating your Fabric network>
+export NETWORKNAME=__NETWORKNAME__
+export MEMBERNAME=__MEMBERNAME__
 export NETWORKVERSION=1.2
-export ADMINUSER=<the admin user name you entered when creating your Fabric network>
-export ADMINPWD=<the admin password you entered when creating your Fabric network>
-export NETWORKID=<your network ID, from the AWS Console>
-export MEMBERID=<your member ID, from the AWS Console>
+export ADMINUSER=__ADMINUSER__
+export ADMINPWD=__ADMINPWD__
+export NETWORKID=__NETWORKID__
+export MEMBERID=__MEMBERID__
 
 # No need to change anything below here
 echo Updating AWS CLI to the latest version

--- a/ngo-rest-api/README.md
+++ b/ngo-rest-api/README.md
@@ -84,37 +84,6 @@ cat ngo-connection-profile.yaml
 ls -lR
 ```
 
-Check the config file used by app.js. Make sure the peer name in config.json (under 'peers:') is 
-the same as the peer name in the connection profile. **Make sure the admin username and 
-password are correct and match the values you updated in the connection profile.**
-
-```
-cd ~/non-profit-blockchain/ngo-rest-api
-sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" config.json
-sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" config.json
-```
-
-config.json should look something like this:
-
-```
-{
-    "host":"localhost",
-    "port":"3000",
-    "channelName":"mychannel",
-    "chaincodeName":"ngo",
-    "eventWaitTime":"30000",
-    "peers":[
-        "peer1"
-    ],
-    "admins":[
-       {
-          "username":"admin", <-- update for your env
-          "secret":"Adminpwd1!" <-- update for your env
-       }
-    ]
- }
-```
-
 ## Step 4 - Run the REST API Node.js application
 On the Fabric client node.
 

--- a/ngo-rest-api/README.md
+++ b/ngo-rest-api/README.md
@@ -90,7 +90,8 @@ password are correct and match the values you updated in the connection profile.
 
 ```
 cd ~/non-profit-blockchain/ngo-rest-api
-vi config.json
+sed -i "s|__ADMINUSER__|<the admin user name you entered when creating your Fabric network>|g" config.json
+sed -i "s|__ADMINPWD__|<the admin password you entered when creating your Fabric network>|g" config.json
 ```
 
 config.json should look something like this:
@@ -182,37 +183,11 @@ response:
 ]
 ```
 ## Step 6 - Load the workshop test data
-In your Cloud9 terminal.
+On the Fabric client node.
 
-You can do this step from anywhere as it accesses the ELB DNS endpoint. Executing this from the SSH
-session is challenging as the SSH session will be outputting a range of INFO logs, which makes it
-challenging to edit files. So you can open another terminal window in Cloud9 and load the test data
-from Cloud9.
+Load the test data using cURL commands similar to those you used above to test the API.  This step outputs a lot of text as it is creating the test data, so if you prefer to run this from a new terminal, you can open a Cloud 9 terminal and SSH into the Fabric client EC2 and create a new session.
 
-Loading the test data uses cURL commands similar to those you used above to test the API. If you load
-the test data from Cloud9 you'll need to point to the AWS Elastic Load Balancer (ELB) that is used to 
-expose your REST API (if you load the test data from your Fabric client node you could use 'localhost'
-as the endpoint since the REST API server is running on the Fabric client node). To find the 
-DNS endpoint for the ELB, go to the CloudFormation stack created in [Part 1](../ngo-fabric/README.md)
-and look for ELBDNS in the Outputs. If you receive an error using the ELB it might be because the underlying EC2 
-instance has not moved to an 'InService' state. This will happen once the REST API server is running
-and the ELB is able to execute the desired number of health checks against it. You can check the 
-status in the EC2 console, under Load Balancers.
-
-```
-cd ~/non-profit-blockchain/ngo-rest-api
-vi ngo-load-workshop.sh
-```
-
-The line to be changed is this one. It should point to your ELB DNS. (it could point to `localhost` 
-if you run this on the Fabric client node. If you use `localhost` you also need to change the port to `3000`):
-
-```
-export ENDPOINT=ngo10-elb-2090058053.us-east-1.elb.amazonaws.com
-export PORT=80
-```
-
-After saving the changes, run the script:
+To run the script:
 
 ```
 cd ~/non-profit-blockchain/ngo-rest-api

--- a/ngo-rest-api/config.json
+++ b/ngo-rest-api/config.json
@@ -9,8 +9,8 @@
     ],
     "admins":[
        {
-          "username":"__ADMINUSER__",
-          "secret":"__ADMINPWD"
+          "username":"admin",
+          "secret":"AdminPwd!"
        }
     ]
  }

--- a/ngo-rest-api/config.json
+++ b/ngo-rest-api/config.json
@@ -9,8 +9,8 @@
     ],
     "admins":[
        {
-          "username":"admin",
-          "secret":"Adminpwd1!"
+          "username":"__ADMINUSER__",
+          "secret":"__ADMINPWD"
        }
     ]
  }

--- a/ngo-rest-api/ngo-load-workshop.sh
+++ b/ngo-rest-api/ngo-load-workshop.sh
@@ -21,10 +21,8 @@
 # The export statements below can be used to point to either localhost or to an ELB endpoint, 
 # depending on where the REST API server is running 
 set +e
-export ENDPOINT=ngo10-elb-2090058053.us-east-1.elb.amazonaws.com
-export PORT=80
-#export ENDPOINT=localhost
-#export PORT=3000
+export ENDPOINT=localhost
+export PORT=3000
 
 echo '---------------------------------------'
 echo connecting to server: $ENDPOINT:$PORT

--- a/ngo-ui/README.md
+++ b/ngo-ui/README.md
@@ -63,20 +63,10 @@ npm i
 
 Your REST API is exposed via an AWS Elastic Load Balancer (ELB). The ELB was created for you
 by CloudFormation in [Part 1](../ngo-fabric/README.md). You can find the DNS endpoint for the ELB in
-the Outputs of your CloudFormation stack in the CloudFormation console.
+the Outputs of your CloudFormation stack in the CloudFormation console.  Replace in the commands below and then execute them.
 
-Edit the file below and change the location of the REST API that the UI depends on:
-
-```
-vi src/environments/environment.ts 
-```
-
-The values to be changed are as follows. The trailing slash is important for the api_url.
-
-```
-  api_url: 'http://tg-fabric-Blockcha-1NVE3TSKYVEQ3-247478291.us-east-1.elb.amazonaws.com/',
-  socket_url: 'ws://tg-fabric-Blockcha-1NVE3TSKYVEQ3-247478291.us-east-1.elb.amazonaws.com'
-```
+sed -i "s|__ELBURL__|<the DNS endpoint for the ELB>|g" src/environments/environment.ts 
+sed -i "s|__ELBURL__|<the DNS endpoint for the ELB>|g" config.json
 
 ## Step 4 - Start the application
 

--- a/ngo-ui/README.md
+++ b/ngo-ui/README.md
@@ -66,7 +66,6 @@ by CloudFormation in [Part 1](../ngo-fabric/README.md). You can find the DNS end
 the Outputs of your CloudFormation stack in the CloudFormation console.  Replace in the commands below and then execute them.
 
 sed -i "s|__ELBURL__|<the DNS endpoint for the ELB>|g" src/environments/environment.ts 
-sed -i "s|__ELBURL__|<the DNS endpoint for the ELB>|g" config.json
 
 ## Step 4 - Start the application
 

--- a/ngo-ui/README.md
+++ b/ngo-ui/README.md
@@ -65,7 +65,12 @@ Your REST API is exposed via an AWS Elastic Load Balancer (ELB). The ELB was cre
 by CloudFormation in [Part 1](../ngo-fabric/README.md). You can find the DNS endpoint for the ELB in
 the Outputs of your CloudFormation stack in the CloudFormation console.  Replace in the commands below and then execute them.
 
-sed -i "s|__ELBURL__|<the DNS endpoint for the ELB>|g" src/environments/environment.ts 
+export REGION=us-east-1
+export FABRICSTACK=ngo-fabric-network
+export ELBURL=$(aws cloudformation --region $REGION describe-stacks --stack-name $FABRICSTACK --query "Stacks[0].Outputs[?OutputKey=='ELBURL'].OutputValue" --output text)
+
+
+sed -i "s|__ELBURL__|$ELBURL|g" src/environments/environment.ts 
 
 ## Step 4 - Start the application
 

--- a/ngo-ui/src/environments/environment.ts
+++ b/ngo-ui/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
   port: '',
   dbhost: '',
   dbport: '',
-  api_url: 'http://ngo10-elb-2090058053.us-east-1.elb.amazonaws.com/',
+  api_url: 'http://__ELBURL__/',
   test: 'test',
-  socket_url: 'ws://ngo10-elb-2090058053.us-east-1.elb.amazonaws.com'
+  socket_url: 'ws://__ELBURL__'
 };


### PR DESCRIPTION
*Description of changes:*
We spend way too much time in our workshops teaching people how to use vi, and at times it feels like we're giving a vi workshop.  I replaced all the cases we use vi with `sed` instead so they can be done from the cli.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
