### PR TITLE
Update ngo-fabric README with pulling in EC2URL from CFN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ README instructions in parts 1-4, in this order:
 * [Part 3:](ngo-rest-api/README.md) Run the RESTful API server. 
 * [Part 4:](ngo-ui/README.md) Run the application. 
 * [Part 5:](new-member/README.md) Add a new member to the network. 
-* [Part 6:](ngo-lambda/README.md) Query the blockchain with a Lambda function. 
+* [Part 6:](ngo-lambda/README.md) Read and write to the blockchain with Amazon API Gateway and AWS Lambda.
 
 ## Cleanup
 

--- a/new-member/README.md
+++ b/new-member/README.md
@@ -899,4 +899,4 @@ The workshop instructions can be found in the README files in parts 1-4:
 * [Part 3:](../ngo-rest-api/README.md) Run the RESTful API server. 
 * [Part 4:](../ngo-ui/README.md) Run the application. 
 * [Part 5:](../new-member/README.md) Add a new member to the network. 
-* [Part 6:](../ngo-lambda/README.md) Query the blockchain with a Lambda function. 
+* [Part 6:](../ngo-lambda/README.md) Read and write to the blockchain with Amazon API Gateway and AWS Lambda.

--- a/ngo-chaincode/README.md
+++ b/ngo-chaincode/README.md
@@ -160,4 +160,4 @@ The workshop instructions can be found in the README files in parts 1-4:
 * [Part 3:](../ngo-rest-api/README.md) Run the RESTful API server. 
 * [Part 4:](../ngo-ui/README.md) Run the application. 
 * [Part 5:](../new-member/README.md) Add a new member to the network. 
-* [Part 6:](../ngo-lambda/README.md) Query the blockchain with a Lambda function. 
+* [Part 6:](../ngo-lambda/README.md) Read and write to the blockchain with Amazon API Gateway and AWS Lambda.

--- a/ngo-fabric/README-events.md
+++ b/ngo-fabric/README-events.md
@@ -100,7 +100,8 @@ Answer 'yes' if prompted: `Are you sure you want to continue connecting (yes/no)
 
 ```
 cd ~
-ssh ec2-user@<dns of EC2 instance> -i ~/<Fabric network name>-keypair.pem
+export EC2URL=$(aws cloudformation describe-stacks --stack-name ngo-fabric-client-node --query "Stacks[0].Outputs[?OutputKey=='EC2URL'].OutputValue" --output text --region $REGION)
+ssh ec2-user@$EC2URL -i ~/{$NETWORKNAME}-keypair.pem
 ```
 
 Clone the repo:
@@ -391,5 +392,4 @@ The workshop instructions can be found in the README files in parts 1-4:
 * [Part 3:](../ngo-rest-api/README.md) Run the RESTful API server. 
 * [Part 4:](../ngo-ui/README.md) Run the application. 
 * [Part 5:](../new-member/README.md) Add a new member to the network. 
-* [Part 6:](../ngo-lambda/README.md) Query the blockchain with a Lambda function. 
-* 
+* [Part 6:](../ngo-lambda/README.md) Read and write to the blockchain with Amazon API Gateway and AWS Lambda.

--- a/ngo-rest-api/README.md
+++ b/ngo-rest-api/README.md
@@ -183,4 +183,4 @@ The workshop instructions can be found in the README files in parts 1-4:
 * [Part 3:](../ngo-rest-api/README.md) Run the RESTful API server. 
 * [Part 4:](../ngo-ui/README.md) Run the application. 
 * [Part 5:](../new-member/README.md) Add a new member to the network.
-* [Part 6:](../ngo-lambda/README.md) Query the blockchain with a Lambda function. 
+* [Part 6:](../ngo-lambda/README.md) Read and write to the blockchain with Amazon API Gateway and AWS Lambda.


### PR DESCRIPTION
*Description of changes:*
- On ngo-fabric, I save the user a step of looking up the ec2 url to ssh into and just pull it in from the cfn stack output
- I updated the description of the Part 6 at the end of each section's readme

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
