### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/ngo-lambda/lambda-api-template.yaml
+++ b/ngo-lambda/lambda-api-template.yaml
@@ -72,7 +72,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: ./src
       FunctionName: !Ref LAMBDANAME
       MemorySize: 512


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #72 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
