### PR TITLE
Fix reusing of stale identity in Lambda

### DIFF
--- a/ngo-lambda/src/setupFabricClient.js
+++ b/ngo-lambda/src/setupFabricClient.js
@@ -20,19 +20,17 @@ const Fabric_Client = require('fabric-client');
 const config = require("./config");
 const logger = require("./logging").getLogger("setupClient");
 
-let _clientInstance;
-
-function getSecretIDForKey(keyName) {
-    return "dev/fabricOrgs/" + config.memberName + "/" + config.fabricUsername + "/" + keyName;
+function getSecretIDForKey(keyName, username) {
+    return "dev/fabricOrgs/" + config.memberName + "/" + username + "/" + keyName;
 }
 
-async function getSecret(keyName) {
+async function getSecret(keyName, username) {
     const client = new AWS.SecretsManager({
         region: "us-east-1"
     });
     
     return new Promise((resolve, reject) => {
-        client.getSecretValue({SecretId: getSecretIDForKey(keyName)}, function(err, data) {
+        client.getSecretValue({SecretId: getSecretIDForKey(keyName, username)}, function(err, data) {
             if (err) {
                 return reject(err);
             }
@@ -52,27 +50,22 @@ async function getSecret(keyName) {
 async function setupClient() {
     
     logger.info("=== setupClient start ===");
-
-    if (!!_clientInstance) {
-        return _clientInstance;
-    }
-
+    
 	let fabric_client = Fabric_Client.loadFromConfig(path.join(__dirname, "./connection-profile.yaml"));
 
-	const username = config.fabricUsername;
 	const store_path = path.join(config.cryptoFolder);
 
 	const crypto_suite = Fabric_Client.newCryptoSuite();
 	const crypto_store = Fabric_Client.newCryptoKeyStore({path: store_path});
 	crypto_suite.setCryptoKeyStore(crypto_store);
 	fabric_client.setCryptoSuite(crypto_suite);
-    
-    const privatePEM = await getSecret("pk");
-    const signedPEM = await getSecret("signcert");
-    
+
+    const username = config.fabricUsername;
+    const privatePEM = await getSecret("pk", username);
+    const signedPEM = await getSecret("signcert", username);
+
 	fabricUser = await fabric_client.createUser({username, mspid: config.mspID, cryptoContent: {privateKeyPEM: privatePEM, signedCertPEM: signedPEM}, skipPersistence: true});
     fabric_client.setUserContext(fabricUser, true);
-    _clientInstance = fabric_client;
 
     logger.info("=== setupClient end ===");
 


### PR DESCRIPTION
*Issue #, if available:*

There was an issue where because Lambda keeps the functions 'warm', the Fabric context could be reused from a previous invocation, which could have been done on behalf of a different user.

*Description of changes:*

No longer persist the client instance, and recreate it on each invocation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
