### PR TITLE
adding ability to run in different region

### DIFF
--- a/ngo-fabric/amb.sh
+++ b/ngo-fabric/amb.sh
@@ -15,5 +15,6 @@
 
 echo Creating Amazon Managed Blockchain network, member and peer node
 aws cloudformation deploy --stack-name $STACKNAME --template-file amb.yaml \
+--parameter-overrides PeerNodeAvailabilityZone=${REGION}a \
 --capabilities CAPABILITY_NAMED_IAM \
 --region $REGION


### PR DESCRIPTION
Added a parameter override to the amb.sh script to use the REGION parameter (which is being set in the workshop) and then just append an 'a' to run in the first AZ.
Alternatively we could use another paramater and set it upfront

*Issue #, if available:*

*Description of changes:*
When run in a different region, the cloudformation stack fails, as the region has been changed but the us-east-1a AZ is hardcoded in the stack YAML

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
