### PR TITLE
Fix hardcoding of path to Cloudformation template

### DIFF
--- a/ngo-events/scripts/deployPrivateSubnet.sh
+++ b/ngo-events/scripts/deployPrivateSubnet.sh
@@ -16,7 +16,8 @@
 REGION=us-east-1
 AZ=us-east-1d
 STACKNAME=private-subnet
-TEMPLATEFILE=../templates/privateSubnet.yaml
+ROOT_FOLDER=~/non-profit-blockchain/ngo-events/
+TEMPLATEFILE=$ROOT_FOLDER/templates/privateSubnet.yaml
 VPC_STACK_NAME=$NETWORKNAME-fabric-client-node
 VPCID=$(aws cloudformation describe-stacks --stack-name $VPC_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='VPCID'].OutputValue" --output text --region $REGION)
 PUBLICSUBNETID=$(aws cloudformation describe-stacks --stack-name $VPC_STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='PublicSubnetID'].OutputValue" --output text --region $REGION )


### PR DESCRIPTION
*Description of changes:*
The previous deployment script only worked if it was run from within the `scripts` folder.  This fix removes that dependency and the script instead relies on the overall project home folder, which is consistent with how we run all of our commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
