### PR TITLE
Adding version specifier for postgres DB creation

### DIFF
--- a/blockchain-explorer/hyperledger-explorer-cfn.yaml
+++ b/blockchain-explorer/hyperledger-explorer-cfn.yaml
@@ -126,6 +126,7 @@ Resources:
       AllocatedStorage:                           !Ref DBStorage
       DBInstanceClass:                            !Ref DBClass
       Engine:                                     postgres
+      EngineVersion:                              12
       MasterUsername:                             !Ref DBUsername
       MasterUserPassword:                         !Ref DBPassword
       DBSubnetGroupName:                          !Ref DBSubnetGroup


### PR DESCRIPTION
AWS will pick the latest version of postgres by default unless specified. RDS does not support an instance type of `db.t2.micro` as referenced on line 47 for postgres beyond version 12.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
