### PR TITLE
Fix array name

### DIFF
--- a/ngo-lambda/src/setupChannel.js
+++ b/ngo-lambda/src/setupChannel.js
@@ -37,7 +37,7 @@ async function setupChannel() {
     if (!peer) {
         let peerEndpoints = config.peerEndpoint.split(",");
         for (let i in peerEndpoints) {
-            channel.addPeer(client.newPeer(peerEndpoint[i], {pem:pemfile}));
+            channel.addPeer(client.newPeer(peerEndpoints[i], {pem:pemfile}));
             // Additional peer settings: https://fabric-sdk-node.github.io/Channel.html#addPeer__anchor
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
No issue # found, but code does not compile.

*Description of changes:*
In file setupChannel.js, the for loop iterates thru the array "peerEndpoints" object but references to this array are not spelled correct, it should be peerEndpoints[i] not peerEndpoint[i].


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
