### PR TITLE
Update NodeJS in CloudFormation and createLambda to 12.x

### DIFF
--- a/ngo-lambda/createLambda.sh
+++ b/ngo-lambda/createLambda.sh
@@ -28,8 +28,8 @@ sudo yum install gcc-c++ -y
 echo Install Node.js. We will use v10.x.
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.0/install.sh | bash
 . ~/.nvm/nvm.sh
-nvm install lts/dubnium
-nvm use lts/dubnium
+nvm install lts/erbium
+nvm use lts/erbium
 cd src
 npm install
 cd ..

--- a/ngo-lambda/lambda-api-template.yaml
+++ b/ngo-lambda/lambda-api-template.yaml
@@ -72,7 +72,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       CodeUri: ./src
       FunctionName: !Ref LAMBDANAME
       MemorySize: 512


### PR DESCRIPTION
…mbda file

*Issue #, if available:*

Node10 is outdated

*Description of changes:*
Changed ngo-lambda/lambda-api-template.yaml to use node12.x
Changed ngo-lambda/createLambda.sh to use lts/erbium (node12)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
